### PR TITLE
Fixed ChartJs test failure due to unsupported canvas op

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+// You only need this file
+// - if you don't want to customize your Jest environment
+// - if you don't want to use Jest i. e. from a Visual Studio Code extension
+const { jestConfig } = require('lwc-services/lib/config/jestConfig');
+
+module.exports = {
+    ...jestConfig,
+    // Adding canvas mock for Chartjs tests
+    setupFiles: ['jest-canvas-mock']
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "description": "Lightning Web Components Recipes Open Source",
     "devDependencies": {
         "husky": "^2.3",
+        "jest-canvas-mock": "^2.1.0",
         "lint-staged": "^8.1.5"
     },
     "engines": {

--- a/src/modules/recipe/libsChartjs/__tests__/libsChartjs.test.js
+++ b/src/modules/recipe/libsChartjs/__tests__/libsChartjs.test.js
@@ -7,8 +7,6 @@ describe('recipe-libs-chartjs', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
-        // Clear mocks so that every test run has a clean implementation
-        jest.clearAllMocks();
     });
 
     it('contains a canvas element for ChartJs', () => {
@@ -19,7 +17,7 @@ describe('recipe-libs-chartjs', () => {
         document.body.appendChild(element);
 
         // Querying the DOM element that has the lwc:dom directive set.
-        const domEl = element.shadowRoot.querySelector('canvas[class="donut"]');
+        const domEl = element.shadowRoot.querySelector('canvas.donut');
         expect(domEl).not.toBeNull();
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,7 +2303,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^0.5.3:
+color-convert@^0.5.3, color-convert@~0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
   integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
@@ -2621,6 +2621,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=
 
 cssnano@~3.10.0:
   version "3.10.0"
@@ -5083,6 +5088,14 @@ istanbul-reports@^2.1.1:
   dependencies:
     handlebars "^4.1.2"
 
+jest-canvas-mock@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.1.0.tgz#6aa129f200d448056515d43d4b34027e6bb2fb36"
+  integrity sha512-1yWLNr6xcmhmADLc5ITOYjXnNl2EWUDlXYpplYqgGdATgZaP8IBp241ihVIfrORM8AhuZW8PXRPdzWBEQOpjBQ==
+  dependencies:
+    cssfontparser "^1.2.1"
+    parse-color "^1.0.0"
+
 jest-changed-files@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.8.0.tgz#7e7eb21cf687587a85e50f3d249d1327e15b157b"
@@ -6801,6 +6814,13 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-color@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-color/-/parse-color-1.0.0.tgz#7b748b95a83f03f16a94f535e52d7f3d94658619"
+  integrity sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=
+  dependencies:
+    color-convert "~0.5.0"
 
 parse-json@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Added `jest-canvas-mock` to the test config and did some minor changes to the test file.