### PR TITLE
Fix findContacts when using uppercase searchKey

### DIFF
--- a/src/modules/data/simpleProvider/simpleProvider.js
+++ b/src/modules/data/simpleProvider/simpleProvider.js
@@ -3,7 +3,7 @@ import { contacts } from 'data/contacts';
 export function findContacts(searchKey) {
     if (searchKey.length === 0) return;
     const results = contacts.filter(
-        item => item.Name.toLowerCase().indexOf(searchKey) !== -1
+        item => item.Name.toLowerCase().indexOf(searchKey.toLowerCase()) !== -1
     );
     // eslint-disable-next-line consistent-return
     return results;


### PR DESCRIPTION
Issue discovered in **CompositionContactSearch** component.
Try to enter 'Wu' in order to find 'Jennifer Wu', it's not working.
It is working only if you enter lower case 'wu'.