### PR TITLE
adding "lwc-webpack-plugin": "^1.2.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "husky": "^6.0.0",
         "jest-canvas-mock": "^2.3.1",
         "lwc-recipes-oss-ui-components": "^0.3.2",
+        "lwc-webpack-plugin": "^1.2.2",
         "lwc-services": "^3.0.4",
         "moment": "^2.29.1",
         "prettier": "^2.2.1"


### PR DESCRIPTION
 I was getting the build failed when using "npm run build" prior to adding **"lwc-webpack-plugin": "^1.2.2"** the error said that it was unable to find the LWC component.
I was using a webpack.config.js
here is the link: https://www.npmjs.com/package/lwc-webpack-plugin

