### PR TITLE
Update dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "scripts": {
         "build": "lwr build",
         "clean": "rm -rf __lwr_cache__ && rm -rf site",
-        "dev": "MODE=dev node scripts/start-server.mjs",
+        "dev": "lwr dev",
         "lint": "eslint **/src/**/*.js",
         "prettier": "prettier --write \"**/*.{css,html,js,mjs,json,md,yaml,yml}\"",
         "prettier:verify": "prettier --check \"**/*.{css,html,js,mjs,json,md,yaml,yml}\"",


### PR DESCRIPTION
### What does this PR do?
Updates the `dev` script in package.json to use LWR's built-in `dev` command. This removes the need to use environment variables to set server mode as 'dev'

### What issues does this PR fix or reference?
TCF-036794: The line "dev": "MODE=dev node scripts/start-server.mjs" in package.json only works in mac and linux and not in windows for windows. I had to change it to "dev": "set MODE=dev&& node scripts/start-server.mjs" for it to work.

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.